### PR TITLE
Two minor fixes

### DIFF
--- a/lib/xapit.rb
+++ b/lib/xapit.rb
@@ -31,12 +31,14 @@ module Xapit
 
     def database
       raise Disabled, "Unable to access Xapit database because it is disabled in configuration." unless Xapit.config[:enabled]
-      if config[:server]
+      if config[:server] && defined?(Rails) != nil
         @database ||= Xapit::Client::RemoteDatabase.new(config[:server])
       elsif config[:read_only]
         @database ||= Xapit::Server::ReadOnlyDatabase.new(config[:database_path])
-      else
+      elsif config[:database_path]
         @database ||= Xapit::Server::Database.new(config[:database_path])
+      else
+        raise Disabled, "Unable to access Xapit database" unless Xapit.config[:enabled]
       end
     end
 

--- a/lib/xapit/client/collection.rb
+++ b/lib/xapit/client/collection.rb
@@ -30,7 +30,7 @@ module Xapit
       end
 
       def where(conditions)
-        scope(:where, where_conditions(conditions))
+        !conditions.empty? ? scope(:where, where_conditions(conditions)) : self
       end
 
       def not_where(conditions)

--- a/lib/xapit/server/query.rb
+++ b/lib/xapit/server/query.rb
@@ -210,7 +210,7 @@ module Xapit
       end
 
       def search_query(text)
-        clean_text = text.gsub(/\b([a-z])\*/i, "\\1").gsub(/[^\w\*\s:]/u, "")
+        clean_text = text.gsub(/\b([a-z])\*/i, "\\1").gsub(/[^\w\*\s:\/()]/u, "")
         xapian_parser.parse_query(clean_text, Xapian::QueryParser::FLAG_WILDCARD | Xapian::QueryParser::FLAG_BOOLEAN) # Xapian::QueryParser::FLAG_LOVEHATE
       end
 


### PR DESCRIPTION
Hi, here comes two minor fixes to your code:
1. Allow ()/ in query strings to allow grouping and things like NEAR/5
2. Don't append empty 'where' conditions, since it later will fail with a:
   Wrong arguments for overloaded method 'Query.new'.
   Possible C/C++ prototypes are:
   Query.new(Xapian::Query const &copyme)
   Query.new()
   Query.new(std::string const &tname_, Xapian::termcount wqf_, Xapian::termpos pos_)
   Query.new(std::string const &tname_, Xapian::termcount wqf_)
   Query.new(std::string const &tname_)
   Query.new(Xapian::Query::op op_, Xapian::Query const &left, Xapian::Query const &right)
   Query.new(Xapian::Query::op op_, std::string const &left, std::string const &right)
   Query.new(Xapian::Query::op op_, Xapian::Query q, double parameter)
   Query.new(Xapian::Query::op op_, Xapian::valueno slot, std::string const &begin, std::string const &end)
   Query.new(Xapian::Query::op op_, Xapian::valueno slot, std::string const &value)
   Query.new(Xapian::PostingSource *external_source)
   Query.new(Xapian::Query::op op, std::vector< Xapian::Query > const &subqs, Xapian::termcount param)
   Query.new(Xapian::Query::op op, std::vector< Xapian::Query > const &subqs)
